### PR TITLE
Make a production docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ EXPOSE 4000
 
 # We run yarn install with an increased network timeout (5min) to avoid "ESOCKETTIMEDOUT" errors from hub.docker.com
 # See, for example https://github.com/yarnpkg/yarn/issues/5540
-RUN yarn install --network-timeout 300000
+RUN yarn global add @angular/cli@13.2.6
+RUN yarn install && yarn run build:prod
+RUN yarn global add pm2
 
 # On startup, run in DEVELOPMENT mode (this defaults to live reloading enabled, etc).
 # Listen / accept connections from all IP addresses.
 # NOTE: At this time it is only possible to run Docker container in Production mode
 # if you have a public IP. See https://github.com/DSpace/dspace-angular/issues/1485
-CMD yarn serve --host 0.0.0.0
+CMD yarn run serve:ssr

--- a/dspace-angular.json
+++ b/dspace-angular.json
@@ -1,0 +1,12 @@
+
+{
+    "apps": [
+        {
+           "name": "dspace-angular",
+           "cwd": "/app/",
+           "script": "yarn",
+           "args": "run serve:ssr",
+           "interpreter": "none"
+        }
+    ]
+}

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -8,5 +8,25 @@ export const environment: Partial<BuildConfig> = {
     preboot: true,
     async: true,
     time: false
-  }
+  },
+  // The "ui" section defines where you want Node.js to run/respond. It often is a *localhost* (non-public) URL, especially if you are using a Proxy.
+  // In this example, we are setting up our UI to just use localhost, port 4000.
+  // This is a common setup for when you want to use Apache or Nginx to handle HTTPS and proxy requests to Node on port 4000
+  ui: {
+    ssl: false,
+    host: 'localhost',
+    port: 4000,
+    // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
+    nameSpace: '/'
+},
+// This example is valid if your Backend is publicly available at https://api.mydspace.edu/server/
+// The REST settings MUST correspond to the primary URL of the backend. Usually, this means they must be kept in sync
+// with the value of "dspace.server.url" in the backend's local.cfg
+rest: {
+    ssl: true,
+    host: 'repository.sarao.ac.za',
+    port: 443,
+    // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
+    nameSpace: '/server'
+}
 };


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Requires DSpace/DSpace#[pr-number] (if a REST API PR is required to test this)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
